### PR TITLE
Changing report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,55 +4,71 @@ about: Create a report to help us improve
 
 ---
 
-**Prerequisites**
-*Please answer the following questions for yourself before submitting an issue. **YOU MAY DELETE THE PREREQUISITES SECTION.**
-	- [ ] I've made sure the game files are ok before installing injector/mods (https://support.steampowered.com/kb_article.php?ref=2037-QEUH-3335)
-	- [ ] I am running the latest version (Master Branch in github)
-	- [ ] I've checked the logs to see if I can find the problematic mod (test the mods one by one if needed)
-	- [ ] I checked the documentation and forums and found no answer
-	- [ ] I checked to make sure that this issue has not already been filed
-	- [ ] I'm reporting the issue to the correct repository (for multi-repository projects)
-	
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Prerequisites
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- Please answer the following questions for yourself before submitting an issue. YOU MAY DELETE THE PREREQUISITES SECTION.-->
 
-**Current behavior**
-What happens instead of the expected behavior
+- [ ] I've made sure the game files are ok before installing injector/mods. <!--(https://support.steampowered.com/kb_article.php?ref=2037-QEUH-3335)-->
+- [ ] I am running the latest version (master Branch in GitHub)
+- [ ] I've checked the logs to see if I can find the problematic mod (test the mods one by one if needed)
+- [ ] I checked the documentation and forums and found no answer
+- [ ] I checked to make sure that this issue has not already been filed
+- [ ] I'm reporting the issue to the correct repository (for multi-repository projects)
 
-**To Reproduce**
-Steps to reproduce the behavior:
+## Bug Description
+
+<!-- A clear and concise description of what the bug is.-->
+
+## Expected Behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Current Behavior
+
+<!-- What happens instead of the expected behavior. -->
+
+## Steps to Reproduce
+
+<!-- Steps to reproduce the behavior. Provide a link to a live example if necessary. -->
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
-Provide a link to a live example if nececessary.
 
-**Possible Solution**
-Suggest a fix for the bug
+## Possible Solution
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- Suggest a fix for the bug -->
 
-**Environment (please complete the following information):**
- - OS: [e.g. Windows]
- - ONI Version [e.g. RU-284634]
- - ONI-Modloader Version [e.g. 0.4.8]
- 
-**Additional context**
-Add any other context about the problem here like used Config files
+## Screenshots
 
-**Output log**
-If applicable (game crashes or displays errors) please copy and paste part of the output_log.txt game file that contains information about the crash/error.
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Environment
+
+<!-- Please complete the following information): -->
+
+- OS: <!-- e.g. Windows -->
+- ONI Version: <!-- e.g. RU-284634 -->
+- ONI-Modloader Version: <!-- e.g. 0.4.8 -->
+
+## Additional context
+
+<!-- Add any other context about the problem here like used Config files -->
+
+## Output log
+
+<!-- If applicable, (game crashes or displays errors) please copy and paste part of the output_log.txt game file that contains information about the crash/error. -->
+
 Check for error logs in:
-* \OxygenNotIncluded\Mods\Mod_Log.txt
-* \OxygenNotIncluded\Mods\_Logs
-* Windows:	%USERPROFILE%\AppData\LocalLow\Klei\Oxygen Not Included\output_log.txt
-* Linux:	$home/.config/unity3d/Klei/Oxygen Not Included/player.log
 
-**Relevant code**
-  ```
-  // TODO(you): code here
-  ```
+- `\OxygenNotIncluded\Mods\Mod_Log.txt`
+- `\OxygenNotIncluded\Mods\_Logs`
+- Windows: `%USERPROFILE%\AppData\LocalLow\Klei\Oxygen Not Included\output_log.txt`
+- Linux: `$home/.config/unity3d/Klei/Oxygen Not Included/player.log`
+
+## Relevant Code
+
+```Csharp
+// TODO(you): code here
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,26 +4,34 @@ about: Suggest an idea for this project
 
 ---
 
-**Prerequisites**
-*Please answer the following questions for yourself before submitting an issue. **YOU MAY DELETE THE PREREQUISITES SECTION.**
-	- [ ] I checked the documentation and forums and found no answer
-	- [ ] I checked to make sure that this feature has not already been filed
-	- [ ] I'm reporting the issue to the correct repository (for multi-repository projects)
+## Prerequisites
 
-**Describe the feature**
-A clear and concise description and motivation of what the feature is.
-	
-**Is your feature request related to a problem?**
-Please describe.
+<!-- Please answer the following questions for yourself before submitting an issue. YOU MAY DELETE THE PREREQUISITES SECTION. -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+- [ ] I checked the documentation and forums and found no answer
+- [ ] I checked to make sure that this feature has not already been filed
+- [ ] I'm reporting the issue to the correct repository (for multi-repository projects)
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Feature Description
 
-**Screenshots**
-If applicable, add screenshots to help explain.
+<!-- A clear and concise description and motivation of what the feature is. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+## Related Problem
+
+<!-- If your feature request related to a problem, please describe. -->
+
+## Possible Solution
+
+<!-- A clear and concise description of what you want to happen. -->
+
+## Alternative Solutions
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain. -->
+
+## Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,17 +4,22 @@ about: Ask a question
 
 ---
 
-**Prerequisites**
-*Please answer the following questions for yourself before submitting an issue. **YOU MAY DELETE THE PREREQUISITES SECTION.**
-	- [ ] I checked the documentation and forums and found no answer
-	- [ ] I checked to make sure that this feature has not already been filed
-	- [ ] I'm reporting the issue to the correct repository (for multi-repository projects)
+## Prerequisites
 
-**What is your Question?**
-A clear and concise description of what the bug is.
+<!-- Please answer the following questions for yourself before submitting an issue. YOU MAY DELETE THE PREREQUISITES SECTION. -->
 
-**What is the context of your question?**
-How and in which context did you come up with the question?
+- [ ] I checked the documentation and forums and found no answer
+- [ ] I checked to make sure that this feature has not already been filed
+- [ ] I'm reporting the issue to the correct repository (for multi-repository projects)
 
-**Additional context**
-Add any other context about the question here.
+## Question Description
+
+<!-- A clear and concise description of your question. -->
+
+## Context
+
+<!-- How and in which context did you come up with the question? -->
+
+## Additional context
+
+<!-- Add any other context about the question here. -->


### PR DESCRIPTION
The indentations appear to break the checkboxes used in GitHub-flavored Markdown. Number of problems reported by markdownlint have also been ratified in this commit.
